### PR TITLE
fix: Unwrapping None value when gathering artist images

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -64,7 +64,6 @@ pub fn update_color_palettes() -> Result<()> {
         if !TRACK_DATA_CACHE.contains_key(&track.id)
             && let Some(image) = IMAGES_CACHE.get(&track.image_url)
             && let Some(artist_image_ref) = ARTIST_DATA_CACHE.get(&track.artist_id)
-            && let Some(artist_image) = IMAGES_CACHE.get(&*artist_image_ref)
         {
             // Merge the images side by side
             let width = image.width;
@@ -86,23 +85,27 @@ pub fn update_color_palettes() -> Result<()> {
                     let artist_new_width = (width as f32 * 0.1).round() as u32;
                     let mut new_img = RgbaImage::new(width + artist_new_width, height);
                     image::imageops::overlay(&mut new_img, &album_image, 0, 0);
-                    let artist_img_resized = image::imageops::resize(
-                        &image::RgbaImage::from_raw(
-                            artist_image.width,
-                            artist_image.height,
-                            artist_image.data.data().to_vec(),
-                        )
-                        .unwrap(),
-                        artist_new_width,
-                        height,
-                        image::imageops::FilterType::Nearest,
-                    );
-                    image::imageops::overlay(
-                        &mut new_img,
-                        &artist_img_resized,
-                        i64::from(width),
-                        0,
-                    );
+                    if let Some(artist_image_ref) = &*artist_image_ref
+                        && let Some(artist_image) = IMAGES_CACHE.get(artist_image_ref)
+                    {
+                        let artist_img_resized = image::imageops::resize(
+                            &image::RgbaImage::from_raw(
+                                artist_image.width,
+                                artist_image.height,
+                                artist_image.data.data().to_vec(),
+                            )
+                            .unwrap(),
+                            artist_new_width,
+                            height,
+                            image::imageops::FilterType::Nearest,
+                        );
+                        image::imageops::overlay(
+                            &mut new_img,
+                            &artist_img_resized,
+                            i64::from(width),
+                            0,
+                        );
+                    }
 
                     let palette: Palette<f64> = Palette::builder()
                         .algorithm(auto_palette::Algorithm::SLIC)

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -55,7 +55,7 @@ pub static PLAYBACK_STATE: LazyLock<RwLock<PlaybackState>> = LazyLock::new(|| {
 pub static IMAGES_CACHE: LazyLock<DashMap<String, ImageData>> = LazyLock::new(DashMap::new);
 pub static TRACK_DATA_CACHE: LazyLock<DashMap<TrackId<'static>, TrackData>> =
     LazyLock::new(DashMap::new);
-pub static ARTIST_DATA_CACHE: LazyLock<DashMap<ArtistId<'static>, String>> =
+pub static ARTIST_DATA_CACHE: LazyLock<DashMap<ArtistId<'static>, Option<String>>> =
     LazyLock::new(DashMap::new);
 
 pub const RATING_PLAYLISTS: [&str; 11] = [
@@ -441,16 +441,15 @@ async fn update_state_from_spotify() {
                     return;
                 };
                 for artist in artists {
-                    let artist_image = artist
-                        .images
-                        .into_iter()
-                        .min_by_key(|img| img.width)
-                        .unwrap();
-                    ARTIST_DATA_CACHE.insert(artist.id, artist_image.url.clone());
+                    let artist_image = artist.images.into_iter().min_by_key(|img| img.width);
+                    ARTIST_DATA_CACHE
+                        .insert(artist.id, artist_image.as_ref().map(|a| a.url.clone()));
                     set.spawn(async move {
-                        let url = artist_image.url.clone();
-                        if let Err(err) = ensure_image_cached(url.as_str()).await {
-                            warn!("failed to cache image {url}: {err}");
+                        if let Some(artist_image) = artist_image {
+                            let url = artist_image.url.clone();
+                            if let Err(err) = ensure_image_cached(url.as_str()).await {
+                                warn!("failed to cache image {url}: {err}");
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
I'm not sure why, but not all artists get images right away, and it crashes the application. This seems to fix the issue? But the images load in one-by-one which might not be desired.